### PR TITLE
version 0.1.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = TMC_2209_Raspberry_Pi
-version = 0.1.4
+version = 0.1.5
 author = Christian Köhlke
 author_email = christian@koehlke.de
 description = this is a Python libary to drive a stepper motor with a Trinamic TMC2209 stepper driver and a Raspberry Pi

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -331,7 +331,33 @@ class TMC_2209:
 #-----------------------------------------------------------------------
 # homes the motor in the given direction using stallguard
 #-----------------------------------------------------------------------
-    def doHoming(self, direction, threshold=None):
+    def doHoming(self, direction, diag_pin, threshold=None):        
+        if(threshold is not None):
+            self._sg_threshold = threshold
+        
+        self.log("---", Loglevel.info.value)
+        self.log("homing", Loglevel.info.value)
+
+        self.setSpreadCycle(0)
+
+        self.log("Stallguard threshold:"+str(self._sg_threshold), Loglevel.debug.value)
+
+        self.setStallguard_Callback(diag_pin, self._sg_threshold, self.stop)
+        
+        if(direction):
+            self.setVActual_rpm(30, revolutions=1)
+        else:
+            self.setVActual_rpm(30, revolutions=-1)
+        self._currentPos = 0
+        
+        self.log("---", Loglevel.info.value)
+        
+
+#-----------------------------------------------------------------------
+# homes the motor in the given direction using stallguard
+# old function, uses STEP/DIR 
+#-----------------------------------------------------------------------
+    def doHoming2(self, direction, threshold=None):
         sg_results = []
         
         if(threshold is not None):
@@ -372,7 +398,6 @@ class TMC_2209:
 
         if(step_counter<self._stepsPerRevolution):
             self.log("homing successful",Loglevel.info.value)
-            self.log("Stepcounter: "+str(step_counter),Loglevel.info.value)
             self.log("Stepcounter: "+str(step_counter),Loglevel.debug.value)
             self.log(str(sg_results),Loglevel.debug.value)
             self._currentPos = 0
@@ -724,12 +749,25 @@ class TMC_2209:
 # It gives the motor velocity in +-(2^23)-1 [μsteps / t]
 # 0: Normal operation. Driver reacts to STEP input
 #-----------------------------------------------------------------------
-    def setVActual(self, vactual):
-        self.log("vactual: "+str(vactual), Loglevel.info.value)
+    def setVActual(self, vactual, duration=0):
+        self._stop = False
+
+        if(duration != 0):
+            self.log("vactual: "+str(vactual)+" for "+str(duration)+" sec", Loglevel.info.value)
+        else:
+            self.log("vactual: "+str(vactual), Loglevel.info.value)
         self.log(str(bin(vactual)), Loglevel.info.value)
 
         self.log("writing vactual", Loglevel.info.value)
         self.tmc_uart.write_reg_check(reg.VACTUAL, vactual)
+
+        if(duration != 0):
+            starttime = time.time()
+            while((not self._stop) and (time.time() < starttime+duration)):
+                pass
+            self.tmc_uart.write_reg_check(reg.VACTUAL, 0)
+            return not self._stop
+
 
 
 #-----------------------------------------------------------------------
@@ -738,17 +776,19 @@ class TMC_2209:
 # With internal oscillator:
 # VACTUAL[2209] = v[Hz] / 0.715Hz
 #-----------------------------------------------------------------------
-    def setVActual_rps(self, rps):
+    def setVActual_rps(self, rps, duration=0, revolutions=0):
         vactual = rps/0.715*self._stepsPerRevolution
-        self.setVActual(int(round(vactual)))
+        if(revolutions!=0):
+            duration = abs(revolutions/rps)
+        return self.setVActual(int(round(vactual)), duration)
 
 
 #-----------------------------------------------------------------------
 # converts the rps parameter to a vactual value which represents
 # rotation speed in revolutions per minute
 #-----------------------------------------------------------------------
-    def setVActual_rpm(self, rpm):
-        self.setVActual_rps(rpm/60)
+    def setVActual_rpm(self, rpm, duration=0, revolutions=0):
+        return self.setVActual_rps(rpm/60, duration, revolutions)
 
 
 #-----------------------------------------------------------------------

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -733,14 +733,22 @@ class TMC_2209:
 
 
 #-----------------------------------------------------------------------
-# sets the register bit "VACTUAL" to to a given value
-# VACTUAL allows moving the motor by UART control.
-# It gives the motor velocity in +-(2^23)-1 [μsteps / t]
-# 0: Normal operation. Driver reacts to STEP input
+# converts the rps parameter to a vactual value which represents
+# rotation speed in revolutions per second
+# With internal oscillator:
+# VACTUAL[2209] = v[Hz] / 0.715Hz
 #-----------------------------------------------------------------------
     def setVActual_rps(self, rps):
         vactual = rps/0.715*self._stepsPerRevolution
         self.setVActual(int(round(vactual)))
+
+
+#-----------------------------------------------------------------------
+# converts the rps parameter to a vactual value which represents
+# rotation speed in revolutions per minute
+#-----------------------------------------------------------------------
+    def setVActual_rpm(self, rpm):
+        self.setVActual_rps(rpm/60)
 
 
 #-----------------------------------------------------------------------

--- a/tests/test_script_04_stallguard.py
+++ b/tests/test_script_04_stallguard.py
@@ -14,7 +14,7 @@ print("---")
 # initiate the TMC_2209 class
 # use your pins for pin_step, pin_dir, pin_en here
 #-----------------------------------------------------------------------
-tmc = TMC_2209(16, 20, 21)
+tmc = TMC_2209(16, 20, 6)
 
 
 
@@ -93,14 +93,27 @@ def my_callback(channel):
     print("StallGuard!")
     tmc.stop()
 
-tmc.setStallguard_Callback(26, 50, my_callback) # after this function call, StallGuard is active
+#tmc.setStallguard_Callback(26, 50, my_callback) # after this function call, StallGuard is active
 
-finishedsuccessfully = tmc.runToPositionSteps(4000, MovementAbsRel.relative)    #move 4000 steps forward
 
-if(finishedsuccessfully == True):
-    print("Movement finished successfully")
-else:
-    print("Movement was not completed")
+
+# finishedsuccessfully = tmc.runToPositionSteps(4000, MovementAbsRel.relative)        #uses STEP/DIR to move the motor
+# finishedsuccessfully = tmc.setVActual_rpm(30, revolutions=10)                     #uses VActual Register to  move the motor
+
+
+# if(finishedsuccessfully == True):
+#     print("Movement finished successfully")
+# else:
+#     print("Movement was not completed")
+
+
+
+
+
+#-----------------------------------------------------------------------
+# deactivate the motor current output
+#-----------------------------------------------------------------------
+tmc.doHoming(True, 50)
 
 
 

--- a/tests/test_script_05_vactual.py
+++ b/tests/test_script_05_vactual.py
@@ -76,28 +76,43 @@ tmc.setMotorEnabled(True)
 # move the motor for 1 second forward, stop for 1 second
 # and then move backwards for 1 second
 #-----------------------------------------------------------------------
-tmc.setVActual(400)
-time.sleep(1)
-tmc.setVActual(0)
-time.sleep(1)
-tmc.setVActual(-400)
-time.sleep(1)
-tmc.setVActual(0)
+#tmc.setVActual(400)
+#time.sleep(1)
+#tmc.setVActual(0)
+#time.sleep(1)
+#tmc.setVActual(-400)
+#time.sleep(1)
+#tmc.setVActual(0)
 
 
 
 
 
 #-----------------------------------------------------------------------
-# setVActual_rps converts 
+# setVActual_rps uses revolutions per seconds as parameter
 #-----------------------------------------------------------------------
 tmc.setVActual_rps(1)
 time.sleep(1)
-tmc.setVActual(0)
+tmc.setVActual_rps(0)
 time.sleep(1)
 tmc.setVActual_rps(-1)
 time.sleep(1)
-tmc.setVActual(0)
+tmc.setVActual_rps(0)
+
+
+
+
+
+#-----------------------------------------------------------------------
+# setVActual_rps uses revolutions per seconds as parameter
+#-----------------------------------------------------------------------
+#tmc.setVActual_rpm(60)
+#time.sleep(1)
+#tmc.setVActual(0)
+#time.sleep(1)
+#tmc.setVActual_rpm(-60)
+#time.sleep(1)
+#tmc.setVActual(0)
 
 
 

--- a/tests/test_script_05_vactual.py
+++ b/tests/test_script_05_vactual.py
@@ -91,13 +91,13 @@ tmc.setMotorEnabled(True)
 #-----------------------------------------------------------------------
 # setVActual_rps uses revolutions per seconds as parameter
 #-----------------------------------------------------------------------
-tmc.setVActual_rps(1)
-time.sleep(1)
-tmc.setVActual_rps(0)
-time.sleep(1)
-tmc.setVActual_rps(-1)
-time.sleep(1)
-tmc.setVActual_rps(0)
+# tmc.setVActual_rps(1)
+# time.sleep(1)
+# tmc.setVActual_rps(0)
+# time.sleep(1)
+# tmc.setVActual_rps(-1)
+# time.sleep(1)
+# tmc.setVActual_rps(0)
 
 
 
@@ -113,6 +113,26 @@ tmc.setVActual_rps(0)
 #tmc.setVActual_rpm(-60)
 #time.sleep(1)
 #tmc.setVActual(0)
+
+
+
+
+
+#-----------------------------------------------------------------------
+# setVActual_rpm and setVActual_rps accept "revolutions" and "duration" as keyword parameter
+# if duration is set the script will set VActual to that rpm for that duration and stop the motor afterwards
+# if revolutions the script will calculate the duration based on the speed and the revolutions
+# Movement of the Motor will not be very accurate with this way
+#-----------------------------------------------------------------------
+tmc.setVActual_rpm(30, revolutions=2)
+
+tmc.setVActual_rpm(-120, revolutions=2)
+
+time.sleep(1)
+
+tmc.setVActual_rpm(30, duration=4)
+
+tmc.setVActual_rpm(-120, duration=1)
 
 
 


### PR DESCRIPTION
- added [setVActual_rpm](https://github.com/Chr157i4n/TMC2209_Raspberry_Pi/commit/34677dfafd2803d3418be04698cea2bbf92b31ac)
- added doHoming function that uses VActual instead of STEP/DIR
- setVActual now accepts a duration, after which the velocity is set to 0
- setVActual_rps and setVActual_rpm now accept duration or revolutions, after which the velocity is set to 0