### PR TITLE
 [#54] Change logger to use logging module instead of print 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# PyCharm files
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## version 0.4.4
+
+- change logger to use logging module
+
 ## version 0.4.3
 
 - small bugfix

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = TMC_2209_Raspberry_Pi
-version = 0.4.3
+version = 0.4.4
 author = Christian Köhlke
 author_email = christian@koehlke.de
 description = this is a Python libary to drive a stepper motor with a Trinamic TMC2209 stepper driver and a Raspberry Pi

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -162,7 +162,7 @@ class TMC_2209:
 
             self.set_motor_enabled(False)
 
-            self.tmc_logger.log("GPIO cleanup")
+            self.tmc_logger.log("GPIO cleanup", Loglevel.INFO)
             if self._pin_step != -1:
                 GPIO.cleanup(self._pin_step)
             if self._pin_dir != -1:

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -100,8 +100,8 @@ class TMC_2209:
 
 
     def __init__(self, pin_en, pin_step=-1, pin_dir=-1, baudrate=115200, serialport="/dev/serial0",
-                 driver_address=0, gpio_mode=GPIO.BCM, loglevel=None, logprefix=None, log_handlers=None,
-                 skip_uart_init=False):
+                 driver_address=0, gpio_mode=GPIO.BCM, loglevel=None, logprefix=None,
+                 log_handlers=None, skip_uart_init=False):
         """constructor
 
         Args:
@@ -114,7 +114,8 @@ class TMC_2209:
             gpio_mode (enum, optional): gpio mode. Defaults to GPIO.BCM.
             loglevel (enum, optional): loglevel. Defaults to None.
             logprefix (str, optional): log prefix. Defaults to None (standard TMC prefix).
-            log_handlers (list, optional): list of logging handlers. Defaults to None (log to console).
+            log_handlers (list, optional): list of logging handlers.
+                Defaults to None (log to console).
             skip_uart_init (bool, optional): skip UART init. Defaults to False.
         """
         if logprefix is None:

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -100,7 +100,8 @@ class TMC_2209:
 
 
     def __init__(self, pin_en, pin_step=-1, pin_dir=-1, baudrate=115200, serialport="/dev/serial0",
-                 driver_address=0, gpio_mode=GPIO.BCM, loglevel=None, skip_uart_init=False):
+                 driver_address=0, gpio_mode=GPIO.BCM, loglevel=None, logprefix=None, log_handlers=None,
+                 skip_uart_init=False):
         """constructor
 
         Args:
@@ -112,9 +113,13 @@ class TMC_2209:
             driver_address (int, optional): driver adress [0-3]. Defaults to 0.
             gpio_mode (enum, optional): gpio mode. Defaults to GPIO.BCM.
             loglevel (enum, optional): loglevel. Defaults to None.
+            logprefix (str, optional): log prefix. Defaults to None (standard TMC prefix).
+            log_handlers (list, optional): list of logging handlers. Defaults to None (log to console).
             skip_uart_init (bool, optional): skip UART init. Defaults to False.
         """
-        self.tmc_logger = TMC_logger(loglevel, f"TMC2209 {driver_address}")
+        if logprefix is None:
+            logprefix = f"TMC2209 {driver_address}"
+        self.tmc_logger = TMC_logger(loglevel, logprefix, log_handlers)
         self.tmc_uart = tmc_uart(self.tmc_logger, serialport, baudrate, driver_address)
 
 

--- a/src/TMC_2209/_TMC_2209_comm.py
+++ b/src/TMC_2209/_TMC_2209_comm.py
@@ -81,7 +81,8 @@ def read_gconf(self):
     self.tmc_logger.log(bin(gconf), Loglevel.INFO)
 
     if gconf & tmc_reg.i_scale_analog:
-        self.tmc_logger.log("Driver is using voltage supplied to VREF as current reference", Loglevel.INFO)
+        self.tmc_logger.log("Driver is using voltage supplied to VREF as current reference",
+                            Loglevel.INFO)
     else:
         self.tmc_logger.log("Driver is using internal reference derived from 5VOUT", Loglevel.INFO)
     if gconf & tmc_reg.internal_rsense:
@@ -104,7 +105,8 @@ def read_gconf(self):
     else:
         self.tmc_logger.log("INDEX shows the first microstep position of sequencer", Loglevel.INFO)
     if gconf & tmc_reg.index_step:
-        self.tmc_logger.log("INDEX output shows step pulses from internal pulse generator", Loglevel.INFO)
+        self.tmc_logger.log("INDEX output shows step pulses from internal pulse generator",
+                            Loglevel.INFO)
     else:
         self.tmc_logger.log("INDEX output as selected by index_otpw", Loglevel.INFO)
     if gconf & tmc_reg.mstep_reg_select:
@@ -128,7 +130,8 @@ def read_gstat(self):
     gstat = self.tmc_uart.read_int(tmc_reg.GSTAT)
     self.tmc_logger.log(bin(gstat), Loglevel.INFO)
     if gstat & tmc_reg.reset:
-        self.tmc_logger.log("The Driver has been reset since the last read access to GSTAT", Loglevel.WARNING)
+        self.tmc_logger.log("The Driver has been reset since the last read access to GSTAT",
+                            Loglevel.WARNING)
     if gstat & tmc_reg.drv_err:
         self.tmc_logger.log("""The driver has been shut down due to overtemperature or
                     short circuit detection since the last read access""", Loglevel.ERROR)
@@ -198,7 +201,8 @@ def read_chopconf(self):
     chopconf = self.tmc_uart.read_int(tmc_reg.CHOPCONF)
     self.tmc_logger.log(bin(chopconf), Loglevel.INFO)
 
-    self.tmc_logger.log(f"native {self.get_microstepping_resolution()} microstep setting", Loglevel.INFO)
+    self.tmc_logger.log(f"native {self.get_microstepping_resolution()} microstep setting",
+                        Loglevel.INFO)
 
     if chopconf & tmc_reg.intpol:
         self.tmc_logger.log("interpolation to 256 µsteps", Loglevel.INFO)

--- a/src/TMC_2209/_TMC_2209_comm.py
+++ b/src/TMC_2209/_TMC_2209_comm.py
@@ -18,53 +18,53 @@ def read_drv_status(self):
     Returns:
         int: 32bit DRV_STATUS Register
     """
-    self.tmc_logger.log("---")
-    self.tmc_logger.log("DRIVER STATUS:")
+    self.tmc_logger.log("---", Loglevel.INFO)
+    self.tmc_logger.log("DRIVER STATUS:", Loglevel.INFO)
     drvstatus =self.tmc_uart.read_int(tmc_reg.DRVSTATUS)
     self.tmc_logger.log(bin(drvstatus), Loglevel.INFO)
     if drvstatus & tmc_reg.stst:
-        self.tmc_logger.log("Info: motor is standing still")
+        self.tmc_logger.log("Motor is standing still", Loglevel.INFO)
     else:
-        self.tmc_logger.log("Info: motor is running")
+        self.tmc_logger.log("Motor is running", Loglevel.INFO)
 
     if drvstatus & tmc_reg.stealth:
-        self.tmc_logger.log("Info: motor is running on StealthChop")
+        self.tmc_logger.log("Motor is running on StealthChop", Loglevel.INFO)
     else:
-        self.tmc_logger.log("Info: motor is running on SpreadCycle")
+        self.tmc_logger.log("Motor is running on SpreadCycle", Loglevel.INFO)
 
     cs_actual = drvstatus & tmc_reg.cs_actual
     cs_actual = cs_actual >> 16
-    self.tmc_logger.log(f"CS actual: {cs_actual}")
+    self.tmc_logger.log(f"CS actual: {cs_actual}", Loglevel.INFO)
 
     if drvstatus & tmc_reg.olb:
-        self.tmc_logger.log("Warning: Open load detected on phase B")
+        self.tmc_logger.log("Open load detected on phase B", Loglevel.WARNING)
 
     if drvstatus & tmc_reg.ola:
-        self.tmc_logger.log("Warning: Open load detected on phase A")
+        self.tmc_logger.log("Open load detected on phase A", Loglevel.WARNING)
 
     if drvstatus & tmc_reg.s2vsb:
-        self.tmc_logger.log("""Error: Short on low-side MOSFET detected on phase B.
-                    The driver becomes disabled""")
+        self.tmc_logger.log("""Short on low-side MOSFET detected on phase B.
+                    The driver becomes disabled""", Loglevel.ERROR)
 
     if drvstatus & tmc_reg.s2vsa:
-        self.tmc_logger.log("""Error: Short on low-side MOSFET detected on phase A.
-                    The driver becomes disabled""")
+        self.tmc_logger.log("""Short on low-side MOSFET detected on phase A.
+                    The driver becomes disabled""", Loglevel.ERROR)
 
     if drvstatus & tmc_reg.s2gb:
-        self.tmc_logger.log("""Error: Short to GND detected on phase B.
-                            The driver becomes disabled.""")
+        self.tmc_logger.log("""Short to GND detected on phase B.
+                            The driver becomes disabled.""", Loglevel.ERROR)
 
     if drvstatus & tmc_reg.s2ga:
-        self.tmc_logger.log("""Error: Short to GND detected on phase A.
-                            The driver becomes disabled.""")
+        self.tmc_logger.log("""Short to GND detected on phase A.
+                            The driver becomes disabled.""", Loglevel.ERROR)
 
     if drvstatus & tmc_reg.ot:
-        self.tmc_logger.log("Error: Driver Overheating!")
+        self.tmc_logger.log("Driver Overheating!", Loglevel.ERROR)
 
     if drvstatus & tmc_reg.otpw:
-        self.tmc_logger.log("Warning: Driver Overheating Prewarning!")
+        self.tmc_logger.log("Driver Overheating Prewarning!", Loglevel.WARNING)
 
-    self.tmc_logger.log("---")
+    self.tmc_logger.log("---", Loglevel.INFO)
     return drvstatus
 
 
@@ -81,38 +81,38 @@ def read_gconf(self):
     self.tmc_logger.log(bin(gconf), Loglevel.INFO)
 
     if gconf & tmc_reg.i_scale_analog:
-        self.tmc_logger.log("Driver is using voltage supplied to VREF as current reference")
+        self.tmc_logger.log("Driver is using voltage supplied to VREF as current reference", Loglevel.INFO)
     else:
-        self.tmc_logger.log("Driver is using internal reference derived from 5VOUT")
+        self.tmc_logger.log("Driver is using internal reference derived from 5VOUT", Loglevel.INFO)
     if gconf & tmc_reg.internal_rsense:
         self.tmc_logger.log("""Internal sense resistors.
-                            Use current supplied into VREF as reference.""")
-        self.tmc_logger.log("VREF pin internally is driven to GND in this mode.")
-        self.tmc_logger.log("This will most likely destroy your driver!!!")
+                            Use current supplied into VREF as reference.""", Loglevel.WARNING)
+        self.tmc_logger.log("VREF pin internally is driven to GND in this mode.", Loglevel.WARNING)
+        self.tmc_logger.log("This will most likely destroy your driver!!!", Loglevel.WARNING)
         raise SystemExit
-    self.tmc_logger.log("Operation with external sense resistors")
+    self.tmc_logger.log("Operation with external sense resistors", Loglevel.INFO)
     if gconf & tmc_reg.en_spreadcycle:
-        self.tmc_logger.log("SpreadCycle mode enabled")
+        self.tmc_logger.log("SpreadCycle mode enabled", Loglevel.INFO)
     else:
-        self.tmc_logger.log("StealthChop PWM mode enabled")
+        self.tmc_logger.log("StealthChop PWM mode enabled", Loglevel.INFO)
     if gconf & tmc_reg.shaft:
-        self.tmc_logger.log("Inverse motor direction")
+        self.tmc_logger.log("Inverse motor direction", Loglevel.INFO)
     else:
-        self.tmc_logger.log("normal motor direction")
+        self.tmc_logger.log("Normal motor direction", Loglevel.INFO)
     if gconf & tmc_reg.index_otpw:
-        self.tmc_logger.log("INDEX pin outputs overtemperature prewarning flag")
+        self.tmc_logger.log("INDEX pin outputs overtemperature prewarning flag", Loglevel.INFO)
     else:
-        self.tmc_logger.log("INDEX shows the first microstep position of sequencer")
+        self.tmc_logger.log("INDEX shows the first microstep position of sequencer", Loglevel.INFO)
     if gconf & tmc_reg.index_step:
-        self.tmc_logger.log("INDEX output shows step pulses from internal pulse generator")
+        self.tmc_logger.log("INDEX output shows step pulses from internal pulse generator", Loglevel.INFO)
     else:
-        self.tmc_logger.log("INDEX output as selected by index_otpw")
+        self.tmc_logger.log("INDEX output as selected by index_otpw", Loglevel.INFO)
     if gconf & tmc_reg.mstep_reg_select:
-        self.tmc_logger.log("Microstep resolution selected by MSTEP register")
+        self.tmc_logger.log("Microstep resolution selected by MSTEP register", Loglevel.INFO)
     else:
-        self.tmc_logger.log("Microstep resolution selected by pins MS1, MS2")
+        self.tmc_logger.log("Microstep resolution selected by pins MS1, MS2", Loglevel.INFO)
 
-    self.tmc_logger.log("---")
+    self.tmc_logger.log("---", Loglevel.INFO)
     return gconf
 
 
@@ -123,19 +123,19 @@ def read_gstat(self):
     Returns:
         int: 3bit GSTAT Register
     """
-    self.tmc_logger.log("---")
-    self.tmc_logger.log("GSTAT")
+    self.tmc_logger.log("---", Loglevel.INFO)
+    self.tmc_logger.log("GSTAT", Loglevel.INFO)
     gstat = self.tmc_uart.read_int(tmc_reg.GSTAT)
     self.tmc_logger.log(bin(gstat), Loglevel.INFO)
     if gstat & tmc_reg.reset:
-        self.tmc_logger.log("The Driver has been reset since the last read access to GSTAT")
+        self.tmc_logger.log("The Driver has been reset since the last read access to GSTAT", Loglevel.WARNING)
     if gstat & tmc_reg.drv_err:
         self.tmc_logger.log("""The driver has been shut down due to overtemperature or
-                    short circuit detection since the last read access""")
+                    short circuit detection since the last read access""", Loglevel.ERROR)
     if gstat & tmc_reg.uv_cp:
         self.tmc_logger.log("""Undervoltage on the charge pump.
-                            The driver is disabled in this case""")
-    self.tmc_logger.log("---")
+                            The driver is disabled in this case""", Loglevel.ERROR)
+    self.tmc_logger.log("---", Loglevel.INFO)
     return gstat
 
 
@@ -158,31 +158,31 @@ def read_ioin(self):
     Returns:
         int: 10+8bit IOIN Register
     """
-    self.tmc_logger.log("---")
-    self.tmc_logger.log("INPUTS")
+    self.tmc_logger.log("---", Loglevel.INFO)
+    self.tmc_logger.log("INPUTS", Loglevel.INFO)
     ioin = self.tmc_uart.read_int(tmc_reg.IOIN)
     self.tmc_logger.log(bin(ioin), Loglevel.INFO)
     if ioin & tmc_reg.io_spread:
-        self.tmc_logger.log("spread is high")
+        self.tmc_logger.log("spread is high", Loglevel.INFO)
     else:
-        self.tmc_logger.log("spread is low")
+        self.tmc_logger.log("spread is low", Loglevel.INFO)
 
     if ioin & tmc_reg.io_dir:
-        self.tmc_logger.log("dir is high")
+        self.tmc_logger.log("dir is high", Loglevel.INFO)
     else:
-        self.tmc_logger.log("dir is low")
+        self.tmc_logger.log("dir is low", Loglevel.INFO)
 
     if ioin & tmc_reg.io_step:
-        self.tmc_logger.log("step is high")
+        self.tmc_logger.log("step is high", Loglevel.INFO)
     else:
-        self.tmc_logger.log("step is low")
+        self.tmc_logger.log("step is low", Loglevel.INFO)
 
     if ioin & tmc_reg.io_enn:
-        self.tmc_logger.log("en is high")
+        self.tmc_logger.log("en is high", Loglevel.INFO)
     else:
-        self.tmc_logger.log("en is low")
+        self.tmc_logger.log("en is low", Loglevel.INFO)
 
-    self.tmc_logger.log("---")
+    self.tmc_logger.log("---", Loglevel.INFO)
     return ioin
 
 
@@ -193,22 +193,22 @@ def read_chopconf(self):
     Returns:
         int: 3bit CHOPCONF Register
     """
-    self.tmc_logger.log("---")
-    self.tmc_logger.log("CHOPPER CONTROL")
+    self.tmc_logger.log("---", Loglevel.INFO)
+    self.tmc_logger.log("CHOPPER CONTROL", Loglevel.INFO)
     chopconf = self.tmc_uart.read_int(tmc_reg.CHOPCONF)
     self.tmc_logger.log(bin(chopconf), Loglevel.INFO)
 
-    self.tmc_logger.log(f"native {self.get_microstepping_resolution()} microstep setting")
+    self.tmc_logger.log(f"native {self.get_microstepping_resolution()} microstep setting", Loglevel.INFO)
 
     if chopconf & tmc_reg.intpol:
-        self.tmc_logger.log("interpolation to 256 µsteps")
+        self.tmc_logger.log("interpolation to 256 µsteps", Loglevel.INFO)
 
     if chopconf & tmc_reg.vsense:
-        self.tmc_logger.log("1: High sensitivity, low sense resistor voltage")
+        self.tmc_logger.log("1: High sensitivity, low sense resistor voltage", Loglevel.INFO)
     else:
-        self.tmc_logger.log("0: Low sensitivity, high sense resistor voltage")
+        self.tmc_logger.log("0: Low sensitivity, high sense resistor voltage", Loglevel.INFO)
 
-    self.tmc_logger.log("---")
+    self.tmc_logger.log("---", Loglevel.INFO)
     return chopconf
 
 

--- a/src/TMC_2209/_TMC_2209_logger.py
+++ b/src/TMC_2209/_TMC_2209_logger.py
@@ -11,9 +11,10 @@ from enum import Enum
 class Loglevel(Enum):
     """loglevel"""
     ALL = 1             # all messages will be logged
-    MOVEMENT = 5        # error, info, debug and movement messages will be logged
-    DEBUG = 10          # error, info and debug messages will be logged
-    INFO = 20           # error and info messages will be logged
+    MOVEMENT = 5        # error, warning, info, debug and movement messages will be logged
+    DEBUG = 10          # error, warning, info and debug messages will be logged
+    INFO = 20           # error, warning and info messages will be logged
+    WARNING = 30        # error and warning messages will be logged
     ERROR = 40          # only error messages will be logged
     NONE = -1           # no messages will be logged
 

--- a/src/TMC_2209/_TMC_2209_logger.py
+++ b/src/TMC_2209/_TMC_2209_logger.py
@@ -1,4 +1,5 @@
 #pylint: disable=invalid-name
+#pylint: disable=protected-access
 """
 TMC_2209 stepper driver logger module
 """
@@ -27,7 +28,8 @@ class TMC_logger:
     log messages from the TMC_2209 lib
     """
 
-    def __init__(self, loglevel: Loglevel = Loglevel.INFO, logprefix: str = "TMC2209", handlers=None):
+    def __init__(self, loglevel: Loglevel = Loglevel.INFO, logprefix: str = "TMC2209",
+                 handlers=None):
         """constructor
 
         Args:
@@ -40,6 +42,7 @@ class TMC_logger:
 
         # Add our custom log levels to the logger
         for level in [Loglevel.ALL, Loglevel.MOVEMENT, Loglevel.NONE]:
+            print(level)
             self._add_logging_level(level.name, level.value)
 
         self.logger = logging.getLogger(logprefix)
@@ -73,7 +76,8 @@ class TMC_logger:
             loglevel (enum): level for which to log
         """
         if loglevel is None:
-            loglevel = Loglevel.INFO        # This is safer than setting it to Loglevel.NONE (no messages will be logged)
+            # This is safer than setting it to Loglevel.NONE (no messages will be logged)
+            loglevel = Loglevel.INFO
         self.loglevel = loglevel
         self.logger.setLevel(loglevel.value)
 
@@ -82,7 +86,8 @@ class TMC_logger:
 
         Args:
             handler (logging.Handler): handler to add
-            formatter (logging.Formatter): formatter for the handler, or None to use the existing formatter (default: None)
+            formatter (logging.Formatter): formatter for the handler,
+                or None to use the existing formatter (default: None)
         """
         if formatter is None:
             formatter = self.formatter
@@ -107,7 +112,8 @@ class TMC_logger:
 
         Args:
             formatter (logging.Formatter): new formatter
-            handlers (list): list of logging handlers to set the new formatting for, or None to set it for all the handlers
+            handlers (list): list of logging handlers to set the new formatting for,
+                or None to set it for all the handlers
                 (default: None)
         """
         self.formatter = formatter
@@ -121,15 +127,16 @@ class TMC_logger:
         if not method_name:
             method_name = level_name.lower()
 
-        '''if hasattr(logging, level_name):
-            raise AttributeError(f"{level_name} already defined in logging module")
-        if hasattr(logging, method_name):
-            raise AttributeError(f"{method_name} already defined in logging module")
-        if hasattr(logging.getLoggerClass(), method_name):
-            raise AttributeError(f"{method_name} already defined in logger class")'''
+        # if hasattr(logging, level_name):
+        #     raise AttributeError(f"{level_name} already defined in logging module")
+        # if hasattr(logging, method_name):
+        #     raise AttributeError(f"{method_name} already defined in logging module")
+        # if hasattr(logging.getLoggerClass(), method_name):
+        #     raise AttributeError(f"{method_name} already defined in logger class")
 
         def logForLevel(self, message, *args, **kwargs):
             if self.isEnabledFor(level_num):
+                print("test")
                 self._log(level_num, message, args, **kwargs)
 
         def logToRoot(message, *args, **kwargs):
@@ -139,6 +146,7 @@ class TMC_logger:
         setattr(logging, level_name, level_num)
         setattr(logging.getLoggerClass(), method_name, logForLevel)
         setattr(logging, method_name, logToRoot)
+
 
     def log(self, message, loglevel: Loglevel = Loglevel.INFO):
         """logs a message

--- a/src/TMC_2209/_TMC_2209_logger.py
+++ b/src/TMC_2209/_TMC_2209_logger.py
@@ -3,74 +3,148 @@
 TMC_2209 stepper driver logger module
 """
 
+import logging
 from enum import Enum
 
 
 
 class Loglevel(Enum):
     """loglevel"""
-    NONE = 0
-    ERROR = 10
-    INFO = 20
-    DEBUG = 30
-    MOVEMENT = 40
-    ALL = 100
+    ALL = 1             # all messages will be logged
+    MOVEMENT = 5        # error, info, debug and movement messages will be logged
+    DEBUG = 10          # error, info and debug messages will be logged
+    INFO = 20           # error and info messages will be logged
+    ERROR = 40          # only error messages will be logged
+    NONE = -1           # no messages will be logged
 
 
 
 class TMC_logger:
-    """TMC_2209_comm
+    """TMC_2209_logger
 
     this class has the function:
-    move the motor via STEP/DIR pins
+    log messages from the TMC_2209 lib
     """
-    _loglevel = Loglevel.INFO
-    _logprefix = "TMC2209"
 
-
-
-    def __init__(self, loglevel = Loglevel.INFO, logprefix = "TMC2209"):
+    def __init__(self, loglevel: Loglevel = Loglevel.INFO, logprefix: str = "TMC2209", handlers=None):
         """constructor
 
         Args:
             logprefix (string): new logprefix
             loglevel (enum): level for which to log
+            handlers (list): list of logging handlers, see logging.handlers (default: None)
         """
-        if loglevel is not None:
-            self._loglevel = loglevel
-        if logprefix is not None:
-            self._logprefix = logprefix
-        else:
-            self._logprefix = "TMC2209"
+        if logprefix is None:
+            logprefix = "TMC2209"
 
+        # Add our custom log levels to the logger
+        for level in [Loglevel.ALL, Loglevel.MOVEMENT, Loglevel.NONE]:
+            self._add_logging_level(level.name, level.value)
 
+        self.logger = logging.getLogger(logprefix)
 
-    def set_logprefix(self, logprefix):
+        self.loglevel = loglevel
+        self.set_loglevel(loglevel)
+        self.formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+        if handlers is None:
+            # Default handler: StreamHandler (logs to console)
+            handlers = [logging.StreamHandler()]
+
+        for handler in handlers:
+            handler.setFormatter(self.formatter)
+            self.logger.addHandler(handler)
+
+        self.logger.propagate = True
+
+    def set_logprefix(self, logprefix: str):
         """set the logprefix.
 
         Args:
             logprefix (string): new logprefix
         """
-        self._logprefix = logprefix
+        self.logger.name = logprefix
 
-
-
-    def set_loglevel(self, loglevel):
+    def set_loglevel(self, loglevel: Loglevel):
         """set the loglevel. See the Enum Loglevel
 
         Args:
             loglevel (enum): level for which to log
         """
-        self._loglevel = loglevel
+        if loglevel is None:
+            loglevel = Loglevel.INFO        # This is safer than setting it to Loglevel.NONE (no messages will be logged)
+        self.loglevel = loglevel
+        self.logger.setLevel(loglevel.value)
 
+    def add_handler(self, handler, formatter=None):
+        """add a handler to the logger
 
+        Args:
+            handler (logging.Handler): handler to add
+            formatter (logging.Formatter): formatter for the handler, or None to use the existing formatter (default: None)
+        """
+        if formatter is None:
+            formatter = self.formatter
+        handler.setFormatter(formatter)
+        self.logger.addHandler(handler)
 
-    def log(self, message, loglevel=Loglevel.NONE):
+    def remove_handler(self, handler):
+        """remove a handler from the logger
+
+        Args:
+            handler (logging.Handler): handler to remove
+        """
+        self.logger.removeHandler(handler)
+
+    def remove_all_handlers(self):
+        """remove all handlers from the logger"""
+        for handler in self.logger.handlers:
+            self.logger.removeHandler(handler)
+
+    def set_formatter(self, formatter, handlers=None):
+        """set a new formatter for the log messages
+
+        Args:
+            formatter (logging.Formatter): new formatter
+            handlers (list): list of logging handlers to set the new formatting for, or None to set it for all the handlers
+                (default: None)
+        """
+        self.formatter = formatter
+        if handlers is None:
+            handlers = self.logger.handlers
+        for handler in handlers:
+            handler.setFormatter(formatter)
+
+    @staticmethod
+    def _add_logging_level(level_name: str, level_num: int, method_name: str = None):
+        if not method_name:
+            method_name = level_name.lower()
+
+        '''if hasattr(logging, level_name):
+            raise AttributeError(f"{level_name} already defined in logging module")
+        if hasattr(logging, method_name):
+            raise AttributeError(f"{method_name} already defined in logging module")
+        if hasattr(logging.getLoggerClass(), method_name):
+            raise AttributeError(f"{method_name} already defined in logger class")'''
+
+        def logForLevel(self, message, *args, **kwargs):
+            if self.isEnabledFor(level_num):
+                self._log(level_num, message, args, **kwargs)
+
+        def logToRoot(message, *args, **kwargs):
+            logging.log(level_num, message, *args, **kwargs)
+
+        logging.addLevelName(level_num, level_name)
+        setattr(logging, level_name, level_num)
+        setattr(logging.getLoggerClass(), method_name, logForLevel)
+        setattr(logging, method_name, logToRoot)
+
+    def log(self, message, loglevel: Loglevel = Loglevel.INFO):
         """logs a message
 
         Args:
             message (string): message to log
-            loglevel (enum): loglevel of this message (Default value = Loglevel.NONE)
+            loglevel (enum): loglevel of this message (Default value = Loglevel.INFO)
         """
-        if self._loglevel.value >= loglevel.value:
-            print(self._logprefix+": " +message)
+        if self.loglevel is not Loglevel.NONE:
+            self.logger.log(loglevel.value, message)

--- a/src/TMC_2209/_TMC_2209_test.py
+++ b/src/TMC_2209/_TMC_2209_test.py
@@ -116,34 +116,34 @@ def test_uart(self):
     self.tmc_logger.log(str(rtn[0:4].hex()), Loglevel.DEBUG)
 
     if len(rtn)==12:
-        self.tmc_logger.log("""the Raspberry Pi received the sended
-                            bits and the answer from the TMC""",Loglevel.INFO)
+        self.tmc_logger.log("""the Raspberry Pi received the sent
+                            bits and the answer from the TMC""", Loglevel.DEBUG)
     elif len(rtn)==4:
-        self.tmc_logger.log("the Raspberry Pi received only the sended bits",
-                            Loglevel.INFO)
+        self.tmc_logger.log("the Raspberry Pi received only the sent bits",
+                            Loglevel.ERROR)
         status = False
     elif len(rtn)==0:
         self.tmc_logger.log("the Raspberry Pi did not receive anything",
-                            Loglevel.INFO)
+                            Loglevel.ERROR)
         status = False
     else:
         self.tmc_logger.log(f"the Raspberry Pi received an unexpected amount of bits: {len(rtn)}",
-                            Loglevel.INFO)
+                            Loglevel.ERROR)
         status = False
 
     if snd[0:4] == rtn[0:4]:
         self.tmc_logger.log("""the Raspberry Pi received exactly the bits it has send.
-                    the first 4 bits are the same""", Loglevel.INFO)
+                    the first 4 bits are the same""", Loglevel.DEBUG)
     else:
         self.tmc_logger.log("""the Raspberry Pi did not received the bits it has send.
-                    the first 4 bits are different""", Loglevel.INFO)
+                    the first 4 bits are different""", Loglevel.DEBUG)
         status = False
 
     self.tmc_logger.log("---")
     if status:
-        self.tmc_logger.log("UART connection: OK")
+        self.tmc_logger.log("UART connection: OK", Loglevel.INFO)
     else:
-        self.tmc_logger.log("UART connection: not OK")
+        self.tmc_logger.log("UART connection: not OK", Loglevel.ERROR)
 
     self.tmc_logger.log("---")
     return True

--- a/src/TMC_2209/_TMC_2209_uart.py
+++ b/src/TMC_2209/_TMC_2209_uart.py
@@ -150,7 +150,8 @@ class TMC_UART:
 
             if(len(rtn)<12 or not_zero_count == 0):
                 self.tmc_logger.log(f"""UART Communication Error:
-                                    {len(rtn_data)} data bytes | {len(rtn)} total bytes""", Loglevel.ERROR)
+                                    {len(rtn_data)} data bytes |
+                                    {len(rtn)} total bytes""", Loglevel.ERROR)
             elif rtn[11] != self.compute_crc8_atm(rtn[4:11]):
                 self.tmc_logger.log("UART Communication Error: CRC MISMATCH", Loglevel.ERROR)
             else:
@@ -279,7 +280,8 @@ class TMC_UART:
             self.tmc_logger.log("Everything looks fine in GSTAT", Loglevel.DEBUG)
         else:
             if gstat & reg.reset:
-                self.tmc_logger.log("The Driver has been reset since the last read access to GSTAT", Loglevel.DEBUG)
+                self.tmc_logger.log("The Driver has been reset since the last read access to GSTAT",
+                                    Loglevel.DEBUG)
             if gstat & reg.drv_err:
                 self.tmc_logger.log("""The driver has been shut down due to overtemperature or short
                       circuit detection since the last read access""", Loglevel.DEBUG)


### PR DESCRIPTION
This PR fixes #54 by replacing the simple print messages in the TMC logger by the python `logging` library. The original TMC logging class remains unchanged, as do its pre-existing function calls, so this update is backward-compatible with code from previous versions. The only thing I had to change was the Loglevel values to make them comply to the default values from `logging`. But I don't image that was actually used other than internally.

The`TMC_logger` now stores a `logging` instance to which all its log messages are saved. The `TMC_logger` also provides extra functions for easy access to the `logging` API, namely adding/removing logging handlers, and setting the message formatting.

I also improved the log levels in some of the log calls in the library, so they match the message content.