### PR TITLE
Include logging formatter to TMC initialization + add example script for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Simultaneous movement of multiple motors can be done with threaded movement.
 
 In this script, the movement of a stepper with threads is shown. This can be used to do other task while moving a motor, or to move several motors simultaneous.
 
+### [demo_script_08_log_to_file.py](demo/demo_script_08_log_to_file.py)
+
+This script shows how you can alter the formatting of the TMC2209 log messages and redirect the log output to a file called `tmc2209_log_file.log` that will be created in the current directory.
+
 \
 \
 For me these baudrates worked fine: 19200, 38400, 57600, 115200, 230400, 460800, 576000.

--- a/demo/demo_script_08_log_to_file.py
+++ b/demo/demo_script_08_log_to_file.py
@@ -1,0 +1,71 @@
+#pylint: disable=wildcard-import
+#pylint: disable=unused-wildcard-import
+#pylint: disable=unused-import
+#pylint: disable=duplicate-code
+"""
+test file for testing writing the log messages to a file
+"""
+
+from src.TMC_2209.TMC_2209_StepperDriver import *
+import logging
+
+print("---")
+print("SCRIPT START")
+print("---")
+
+
+#-----------------------------------------------------------------------
+# initiate the log level, handler, and formatter
+#-----------------------------------------------------------------------
+loglevel = Loglevel.ALL
+logging_handler = logging.FileHandler("tmc2209_log_file.log")
+logformatter = logging.Formatter('%(name)s %(asctime)s - %(levelname)s - %(message)s', '%Y%m%d %H:%M:%S')
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# initiate the TMC_2209 class
+# use your pins for pin_en, pin_step, pin_dir here
+#-----------------------------------------------------------------------
+if BOARD == "RASPBERRY_PI":
+    tmc = TMC_2209(21, 16, 20, skip_uart_init=True,
+                   loglevel=loglevel, log_handlers=[logging_handler], log_formatter=logformatter)
+elif BOARD == "NVIDIA_JETSON":
+    tmc = TMC_2209(13, 6, 5, serialport="/dev/ttyTHS1", skip_uart_init=True,
+                   loglevel=loglevel, log_handlers=[logging_handler], log_formatter=logformatter)
+else:
+    # just in case
+    tmc = TMC_2209(21, 16, 20, skip_uart_init=True,
+                   loglevel=loglevel, log_handlers=[logging_handler], log_formatter=logformatter)
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Log custom messages
+#-----------------------------------------------------------------------
+tmc.tmc_logger.log("Hello World!", Loglevel.DEBUG)
+tmc.tmc_logger.log("Wow, you can even log your own messages!", Loglevel.ERROR)
+tmc.tmc_logger.log("If you like this library, please give us a star on GitHub!", Loglevel.INFO)
+tmc.tmc_logger.log("The cake is a lie", Loglevel.WARNING)
+tmc.tmc_logger.log("I like to move it, move it", Loglevel.MOVEMENT)
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# deinitiate the TMC_2209 class
+#-----------------------------------------------------------------------
+del tmc
+
+print("---")
+print("SCRIPT FINISHED")
+print("---")
+

--- a/demo/demo_script_08_log_to_file.py
+++ b/demo/demo_script_08_log_to_file.py
@@ -49,12 +49,13 @@ else:
 #-----------------------------------------------------------------------
 # Log custom messages
 #-----------------------------------------------------------------------
+tmc.tmc_logger.log("========================", Loglevel.ALL)
 tmc.tmc_logger.log("Hello World!", Loglevel.DEBUG)
 tmc.tmc_logger.log("Wow, you can even log your own messages!", Loglevel.ERROR)
 tmc.tmc_logger.log("If you like this library, please give us a star on GitHub!", Loglevel.INFO)
 tmc.tmc_logger.log("The cake is a lie", Loglevel.WARNING)
 tmc.tmc_logger.log("I like to move it, move it", Loglevel.MOVEMENT)
-
+tmc.tmc_logger.log("========================", Loglevel.ALL)
 
 
 

--- a/demo/demo_script_08_log_to_file.py
+++ b/demo/demo_script_08_log_to_file.py
@@ -6,8 +6,10 @@
 test file for testing writing the log messages to a file
 """
 
-from src.TMC_2209.TMC_2209_StepperDriver import *
 import logging
+from src.TMC_2209.TMC_2209_StepperDriver import *
+
+
 
 print("---")
 print("SCRIPT START")
@@ -19,7 +21,8 @@ print("---")
 #-----------------------------------------------------------------------
 loglevel = Loglevel.ALL
 logging_handler = logging.FileHandler("tmc2209_log_file.log")
-logformatter = logging.Formatter('%(name)s %(asctime)s - %(levelname)s - %(message)s', '%Y%m%d %H:%M:%S')
+logformatter = logging.Formatter('%(name)s %(asctime)s - %(levelname)s - %(message)s',
+                                 '%Y%m%d %H:%M:%S')
 
 
 
@@ -69,4 +72,3 @@ del tmc
 print("---")
 print("SCRIPT FINISHED")
 print("---")
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = TMC_2209_Raspberry_Pi
-version = 0.4.4
+version = 0.4.5
 author = Christian Köhlke
 author_email = christian@koehlke.de
 description = this is a Python libary to drive a stepper motor with a Trinamic TMC2209 stepper driver and a Raspberry Pi

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -15,6 +15,7 @@ this module has two different functions:
 
 import time
 import statistics
+import logging
 from ._TMC_2209_GPIO_board import GPIO, BOARD
 from ._TMC_2209_uart import TMC_UART as tmc_uart
 from ._TMC_2209_logger import TMC_logger, Loglevel
@@ -101,7 +102,7 @@ class TMC_2209:
 
     def __init__(self, pin_en, pin_step=-1, pin_dir=-1, baudrate=115200, serialport="/dev/serial0",
                  driver_address=0, gpio_mode=GPIO.BCM, loglevel=None, logprefix=None,
-                 log_handlers=None, skip_uart_init=False):
+                 log_handlers: list = None, log_formatter : logging.Formatter = None, skip_uart_init: bool = False):
         """constructor
 
         Args:
@@ -113,14 +114,16 @@ class TMC_2209:
             driver_address (int, optional): driver adress [0-3]. Defaults to 0.
             gpio_mode (enum, optional): gpio mode. Defaults to GPIO.BCM.
             loglevel (enum, optional): loglevel. Defaults to None.
-            logprefix (str, optional): log prefix. Defaults to None (standard TMC prefix).
+            logprefix (str, optional): log prefix (name of the logger). Defaults to None (standard TMC prefix).
             log_handlers (list, optional): list of logging handlers.
                 Defaults to None (log to console).
+            log_formatter (logging.Formatter, optional): formatter for the log messages. Defaults to None (messages are
+                logged in the format '%(asctime)s - %(name)s - %(levelname)s - %(message)s').
             skip_uart_init (bool, optional): skip UART init. Defaults to False.
         """
         if logprefix is None:
             logprefix = f"TMC2209 {driver_address}"
-        self.tmc_logger = TMC_logger(loglevel, logprefix, log_handlers)
+        self.tmc_logger = TMC_logger(loglevel, logprefix, log_handlers, log_formatter)
         self.tmc_uart = tmc_uart(self.tmc_logger, serialport, baudrate, driver_address)
 
 

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -102,7 +102,8 @@ class TMC_2209:
 
     def __init__(self, pin_en, pin_step=-1, pin_dir=-1, baudrate=115200, serialport="/dev/serial0",
                  driver_address=0, gpio_mode=GPIO.BCM, loglevel=None, logprefix=None,
-                 log_handlers: list = None, log_formatter : logging.Formatter = None, skip_uart_init: bool = False):
+                 log_handlers: list = None, log_formatter : logging.Formatter = None,
+                 skip_uart_init: bool = False):
         """constructor
 
         Args:
@@ -114,11 +115,13 @@ class TMC_2209:
             driver_address (int, optional): driver adress [0-3]. Defaults to 0.
             gpio_mode (enum, optional): gpio mode. Defaults to GPIO.BCM.
             loglevel (enum, optional): loglevel. Defaults to None.
-            logprefix (str, optional): log prefix (name of the logger). Defaults to None (standard TMC prefix).
+            logprefix (str, optional): log prefix (name of the logger).
+                Defaults to None (standard TMC prefix).
             log_handlers (list, optional): list of logging handlers.
                 Defaults to None (log to console).
-            log_formatter (logging.Formatter, optional): formatter for the log messages. Defaults to None (messages are
-                logged in the format '%(asctime)s - %(name)s - %(levelname)s - %(message)s').
+            log_formatter (logging.Formatter, optional): formatter for the log messages.
+                Defaults to None (messages are logged in the format
+                '%(asctime)s - %(name)s - %(levelname)s - %(message)s').
             skip_uart_init (bool, optional): skip UART init. Defaults to False.
         """
         if logprefix is None:

--- a/src/TMC_2209/_TMC_2209_logger.py
+++ b/src/TMC_2209/_TMC_2209_logger.py
@@ -29,13 +29,14 @@ class TMC_logger:
     """
 
     def __init__(self, loglevel: Loglevel = Loglevel.INFO, logprefix: str = "TMC2209",
-                 handlers=None):
+                 handlers: list = None, formatter: logging.Formatter = None):
         """constructor
 
         Args:
-            logprefix (string): new logprefix
+            logprefix (string): new logprefix (name of the logger) (default: "TMC2209")
             loglevel (enum): level for which to log
             handlers (list): list of logging handlers, see logging.handlers (default: None)
+            formatter (logging.Formatter): formatter for the log messages (default: None)
         """
         if logprefix is None:
             logprefix = "TMC2209"
@@ -49,7 +50,9 @@ class TMC_logger:
 
         self.loglevel = loglevel
         self.set_loglevel(loglevel)
-        self.formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        if formatter is None:
+            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        self.formatter = formatter
 
         if handlers is None:
             # Default handler: StreamHandler (logs to console)

--- a/src/TMC_2209/_TMC_2209_logger.py
+++ b/src/TMC_2209/_TMC_2209_logger.py
@@ -43,7 +43,6 @@ class TMC_logger:
 
         # Add our custom log levels to the logger
         for level in [Loglevel.ALL, Loglevel.MOVEMENT, Loglevel.NONE]:
-            print(level)
             self._add_logging_level(level.name, level.value)
 
         self.logger = logging.getLogger(logprefix)
@@ -139,7 +138,6 @@ class TMC_logger:
 
         def logForLevel(self, message, *args, **kwargs):
             if self.isEnabledFor(level_num):
-                print("test")
                 self._log(level_num, message, args, **kwargs)
 
         def logToRoot(message, *args, **kwargs):


### PR DESCRIPTION
This PR ensures that you can pass the logging formatter as a parameter during init of the TMC instance. Previously you could only set this after the TMC init, so the log messages created during the TMC initialization used default formatting.

I also removed some debug print statements in the logger code that I accidentally left in my previous PR (sorry!).

Additionally, I created an example script for using the logger. This script sets a custom formatting and creates a log handler for writing the log output to a file `tmc2209_log_file.log` that is created in the current directory:
<img width="905" alt="image" src="https://github.com/Chr157i4n/TMC2209_Raspberry_Pi/assets/11031519/8672f49c-e9f8-4c4b-82ac-8a5d9374c071">
