### PR TITLE
Import from the TMC_2209 lib if the src module is not available in the demo scripts

### DIFF
--- a/demo/debug_script_01_uart_connection.py
+++ b/demo/debug_script_01_uart_connection.py
@@ -7,7 +7,10 @@ debug file for debuging the UART connection
 """
 
 import time
-from src.TMC_2209.TMC_2209_StepperDriver import *
+try:
+    from src.TMC_2209.TMC_2209_StepperDriver import *
+except ModuleNotFoundError:
+    from TMC_2209.TMC_2209_StepperDriver import *
 
 
 print("---")

--- a/demo/demo_script_01_uart_connection.py
+++ b/demo/demo_script_01_uart_connection.py
@@ -7,7 +7,10 @@ test file for testing the UART connection
 """
 
 import time
-from src.TMC_2209.TMC_2209_StepperDriver import *
+try:
+    from src.TMC_2209.TMC_2209_StepperDriver import *
+except ModuleNotFoundError:
+    from TMC_2209.TMC_2209_StepperDriver import *
 
 
 print("---")

--- a/demo/demo_script_02_pin_connection.py
+++ b/demo/demo_script_02_pin_connection.py
@@ -7,7 +7,10 @@ test file for testing the STEP, DIR, EN connection
 """
 
 import time
-from src.TMC_2209.TMC_2209_StepperDriver import *
+try:
+    from src.TMC_2209.TMC_2209_StepperDriver import *
+except ModuleNotFoundError:
+    from TMC_2209.TMC_2209_StepperDriver import *
 
 
 print("---")

--- a/demo/demo_script_03_basic_movement.py
+++ b/demo/demo_script_03_basic_movement.py
@@ -7,7 +7,10 @@ test file for testing basic movement
 """
 
 import time
-from src.TMC_2209.TMC_2209_StepperDriver import *
+try:
+    from src.TMC_2209.TMC_2209_StepperDriver import *
+except ModuleNotFoundError:
+    from TMC_2209.TMC_2209_StepperDriver import *
 
 
 print("---")

--- a/demo/demo_script_04_stallguard.py
+++ b/demo/demo_script_04_stallguard.py
@@ -7,7 +7,10 @@ test file for testing the StallGuard feature
 """
 
 import time
-from src.TMC_2209.TMC_2209_StepperDriver import *
+try:
+    from src.TMC_2209.TMC_2209_StepperDriver import *
+except ModuleNotFoundError:
+    from TMC_2209.TMC_2209_StepperDriver import *
 
 
 print("---")

--- a/demo/demo_script_05_vactual.py
+++ b/demo/demo_script_05_vactual.py
@@ -7,7 +7,10 @@ test file for testing the VActual
 """
 
 import time
-from src.TMC_2209.TMC_2209_StepperDriver import *
+try:
+    from src.TMC_2209.TMC_2209_StepperDriver import *
+except ModuleNotFoundError:
+    from TMC_2209.TMC_2209_StepperDriver import *
 
 
 print("---")

--- a/demo/demo_script_06_multiple_drivers.py
+++ b/demo/demo_script_06_multiple_drivers.py
@@ -8,7 +8,10 @@ test file for testing multiple drivers via one UART connection
 """
 
 import time
-from src.TMC_2209.TMC_2209_StepperDriver import *
+try:
+    from src.TMC_2209.TMC_2209_StepperDriver import *
+except ModuleNotFoundError:
+    from TMC_2209.TMC_2209_StepperDriver import *
 
 
 print("---")

--- a/demo/demo_script_07_threads.py
+++ b/demo/demo_script_07_threads.py
@@ -7,7 +7,10 @@ test file for testing movement of motors with threads
 """
 
 import time
-from src.TMC_2209.TMC_2209_StepperDriver import *
+try:
+    from src.TMC_2209.TMC_2209_StepperDriver import *
+except ModuleNotFoundError:
+    from TMC_2209.TMC_2209_StepperDriver import *
 
 print("---")
 print("SCRIPT START")

--- a/demo/demo_script_08_log_to_file.py
+++ b/demo/demo_script_08_log_to_file.py
@@ -7,7 +7,10 @@ test file for testing writing the log messages to a file
 """
 
 import logging
-from src.TMC_2209.TMC_2209_StepperDriver import *
+try:
+    from src.TMC_2209.TMC_2209_StepperDriver import *
+except ModuleNotFoundError:
+    from TMC_2209.TMC_2209_StepperDriver import *
 
 
 


### PR DESCRIPTION
Sometimes I download the demo scripts to test my motor driver connection. However, when I run the demo scripts, I get a `ModuleNotFoundError` that the `src` module cannot be found (because I just downloaded the demo scripts, not the entire repo).

This PR attempts to load the TMC_2209 module from the pip installed library when it cannot find the TMC_2209 in the `src` module.