### PR TITLE
added toff setting

### DIFF
--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -41,7 +41,7 @@ class TMC_2209:
         read_microstepping_resolution, get_microstepping_resolution, set_microstepping_resolution,
         set_mstep_resolution_reg_select, get_interface_transmission_counter, get_tstep, set_vactual,
         get_stallguard_result, set_stallguard_threshold, set_coolstep_threshold,
-        get_microstep_counter, get_microstep_counter_in_steps
+        get_microstep_counter, get_microstep_counter_in_steps, set_toff
     )
 
     from ._TMC_2209_move import (

--- a/src/TMC_2209/_TMC_2209_comm.py
+++ b/src/TMC_2209/_TMC_2209_comm.py
@@ -505,6 +505,31 @@ def set_interpolation(self, en):
 
 
 
+def set_toff(self, toff):
+    """Sets TOFF register to value
+
+    Args:
+        toff (uint8_t): value of toff (must be a four-bit value)
+    """
+    # Ensure toff is a four-bit value by zeroing out the top bits
+    toff = toff & 0x0F
+
+    # Read the current value of the CHOPCONF register
+    chopconf = self.tmc_uart.read_int(tmc_reg.CHOPCONF)
+
+    # Zero out the lower four bits of the CHOPCONF register
+    chopconf = chopconf & 0xFFFFFFF0
+
+    # Set the lower four bits of CHOPCONF to the toff value
+    chopconf = chopconf | toff
+
+    # Write the new value back to the CHOPCONF register
+    self.tmc_uart.write_reg_check(tmc_reg.CHOPCONF, chopconf)
+
+    # Log the action
+    self.tmc_logger.log(f"writing toff setting: {str(toff)}", Loglevel.INFO)
+
+
 def read_microstepping_resolution(self):
     """returns the current native microstep resolution (1-256)
     this reads the value from the driver register


### PR DESCRIPTION
Simply added setting to control toff field which allows to set the current completely to OFF but still have the TMC set to enabled (with enable pin). For me it reduces the need to have EN wired to a GPIO