### PR TITLE
Add extra checks for when serial is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## version 0.5.2
+
+- added extra error handling for when the UART serial is not set
+
 ## version 0.5.1
 
 - added toff setting

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = TMC_2209_Raspberry_Pi
-version = 0.5.1
+version = 0.5.2
 author = Christian Köhlke
 author_email = christian@koehlke.de
 description = this is a Python libary to drive a stepper motor with a Trinamic TMC2209 stepper driver and a Raspberry Pi

--- a/src/TMC_2209/_TMC_2209_move.py
+++ b/src/TMC_2209/_TMC_2209_move.py
@@ -85,7 +85,10 @@ def set_max_speed(self, speed):
         speed = -speed
     if self._max_speed != speed:
         self._max_speed = speed
-        self._cmin = 1000000.0 / speed
+        if speed == 0.0:
+            self._cmin = 0.0
+        else:
+            self._cmin = 1000000.0 / speed
         # Recompute _n from current speed and adjust speed if accelerating or cruising
         if self._n > 0:
             self._n = (self._speed * self._speed) / (2.0 * self._acceleration) # Equation 16

--- a/src/TMC_2209/_TMC_2209_uart.py
+++ b/src/TMC_2209/_TMC_2209_uart.py
@@ -144,17 +144,15 @@ class TMC_UART:
 
 
 
-    def read_int(self, register, tries=10, bypass_serial=False):
+    def read_int(self, register, tries=10):
         """this function tries to read the registry of the TMC 10 times
         if a valid answer is returned, this function returns it as an integer
 
         Args:
             register (int): HEX, which register to read
             tries (int): how many tries, before error is raised (Default value = 10)
-            bypass_serial (bool): if True, the serial connection is not checked
-                (Default value = False)
         """
-        if not bypass_serial and self.ser is None:
+        if self.ser is None:
             self.tmc_logger.log("Cannot read int, serial is not initialized", Loglevel.ERROR)
             return -1
         while True:

--- a/src/TMC_2209/_TMC_2209_uart.py
+++ b/src/TMC_2209/_TMC_2209_uart.py
@@ -151,7 +151,8 @@ class TMC_UART:
         Args:
             register (int): HEX, which register to read
             tries (int): how many tries, before error is raised (Default value = 10)
-            bypass_serial (bool): if True, the serial connection is not checked (Default value = False)
+            bypass_serial (bool): if True, the serial connection is not checked
+                (Default value = False)
         """
         if not bypass_serial and self.ser is None:
             self.tmc_logger.log("Cannot read int, serial is not initialized", Loglevel.ERROR)

--- a/src/TMC_2209/_TMC_2209_uart.py
+++ b/src/TMC_2209/_TMC_2209_uart.py
@@ -144,15 +144,16 @@ class TMC_UART:
 
 
 
-    def read_int(self, register, tries=10):
+    def read_int(self, register, tries=10, bypass_serial=False):
         """this function tries to read the registry of the TMC 10 times
         if a valid answer is returned, this function returns it as an integer
 
         Args:
             register (int): HEX, which register to read
             tries (int): how many tries, before error is raised (Default value = 10)
+            bypass_serial (bool): if True, the serial connection is not checked (Default value = False)
         """
-        if self.ser is None:
+        if not bypass_serial and self.ser is None:
             self.tmc_logger.log("Cannot read int, serial is not initialized", Loglevel.ERROR)
             return -1
         while True:

--- a/tests/test_TMC_2209_uart.py
+++ b/tests/test_TMC_2209_uart.py
@@ -24,9 +24,10 @@ class TestTMCUart(unittest.TestCase):
 
     def test_read_int(self):
         """test_read_int"""
+        self.tmc_uart.ser = 1 # to avoid early return, due to ser being None
         with mock.patch.object(TMC_UART, 'read_reg', return_value=
                                b'U\x00o\x03\x05\xffo\xc0\x1e\x00\x00\xca'):
-            reg_ans = self.tmc_uart.read_int(0x00, bypass_serial=True)
+            reg_ans = self.tmc_uart.read_int(0x00)
             self.assertEqual(reg_ans, -1071775744, "read_int is wrong")
 
 

--- a/tests/test_TMC_2209_uart.py
+++ b/tests/test_TMC_2209_uart.py
@@ -26,7 +26,7 @@ class TestTMCUart(unittest.TestCase):
         """test_read_int"""
         with mock.patch.object(TMC_UART, 'read_reg', return_value=
                                b'U\x00o\x03\x05\xffo\xc0\x1e\x00\x00\xca'):
-            reg_ans = self.tmc_uart.read_int(0x00)
+            reg_ans = self.tmc_uart.read_int(0x00, bypass_serial=True)
             self.assertEqual(reg_ans, -1071775744, "read_int is wrong")
 
 


### PR DESCRIPTION
I tested the lib on my Mac today, and found that when setting the serialport to None, the program would crash because some parts of `TMC_UART` referenced `self.ser` without a None-check. This PR adds extra error checks for this.

Strangely, this only occurred after I switched my app's virtual environment from a normal venv to a Poetry venv. In any case, this error handling should be implemented.