### PR TITLE
Added support for Orange Pi boards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can read more about this in the datasheet from Trinamic.
 Because the TMC2209 uses one shared pin for transmit and receive in the UART communication line, the Raspberry Pi also receives what it sends.
 Well, the Pi receives 4 bytes from itself and 8 bytes from the driver. So the Pi receives a total of 12 bytes and only the last 8 are the reply, of which only 4 are data bytes.
 
-The Documentation of the TMC2209 can be found here:  
+The Documentation of the TMC2209 can be found here:
 [TMC2209 - Datsheet](https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC2209_Datasheet_rev1.06.pdf)
 
 The code is also available on [PyPI](https://pypi.org/project/TMC-2209-Raspberry-Pi).
@@ -60,12 +60,14 @@ pip3 install TMC-2209-Raspberry-Pi
 
 The following table shows the supported boards and which libraries for GPIO access is beeing used for that board.
 
-Library | Installation Parameter | Boards
--- | -- | --
-RPi.GPIO | RASPBERRY_PI | Pi4, Pi3 etc.
-gpiozero | RASPBERRY_PI5 | Pi5
-Jetson.GPIO | NVIDIA_JETSON | Nvidia Jetson
-pheriphery | LUCKFOX_PICO | Luckfox Pico
+Library     | Installation Parameter    | Boards
+----------- | ------------------------- | -----------
+RPi.GPIO    | RASPBERRY_PI              | Pi4, Pi3 etc.
+gpiozero    | RASPBERRY_PI5             | Pi5
+Jetson.GPIO | NVIDIA_JETSON             | Nvidia Jetson
+pheriphery  | LUCKFOX_PICO              | Luckfox Pico
+pheriphery  | LUCKFOX_PICO              | Luckfox Pico
+OPi.GPIO    | ORANGE_PI                 | Orange Pi
 
 Those libraries are needed for this library to work. You can either install the correct library yourself.
 You can also install the needed GPIO library by specifing the Installation Parameter while installing this library:

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,5 @@ NVIDIA_JETSON =
     Jetson.GPIO
 LUCKFOX_PICO =
     python-periphery
+ORANGE_PI =
+    OPi.GPIO

--- a/src/TMC_2209/_TMC_2209_GPIO_board.py
+++ b/src/TMC_2209/_TMC_2209_GPIO_board.py
@@ -24,6 +24,7 @@ from ._TMC_2209_logger import TMC_logger, Loglevel
 # Jetson.GPIO   | Nvidia Jetson
 # gpiozero      | Pi5
 # pheriphery    | Luckfox Pico
+# OPi.GPIO      | Orange Pi
 # ------------------------------
 
 class Board(Enum):
@@ -33,6 +34,7 @@ class Board(Enum):
     RASPBERRY_PI5 = 2
     NVIDIA_JETSON = 3
     LUCKFOX_PICO = 4
+    ORANGE_PI = 5
 
 class Gpio(IntEnum):
     """GPIO value"""
@@ -150,6 +152,19 @@ else:
                     "Exiting..."),
                 Loglevel.ERROR)
                 raise
+        elif "orange" in model:
+            try:
+                from OPi import GPIO
+                BOARD = Board.ORANGE_PI
+            except ModuleNotFoundError as err:
+                dependencies_logger.log(
+                    (f"ModuleNotFoundError: {err}\n"
+                    "Board is Orange Pi but module OPi.GPIO isn't installed.\n"
+                    "Follow the installation instructions in the link below to resolve the issue:\n"
+                    "https://github.com/rm-hull/OPi.GPIO\n"
+                    "Exiting..."),
+                Loglevel.ERROR)
+                raise
         else:
             # just in case
             dependencies_logger.log(
@@ -174,6 +189,8 @@ class TMC_gpio:
         if BOARD == Board.RASPBERRY_PI5:
             pass
         elif BOARD == Board.LUCKFOX_PICO:
+            pass
+        elif BOARD == Board.ORANGE_PI:
             pass
         else:
             GPIO.setwarnings(False)


### PR DESCRIPTION
I have an Orange Pi Zero 2W hooked up to my TMC2209 in UART mode.
I added the support for the OPi.GPIO library that is a drop-in port of the RPi.GPIO library.
https://github.com/rm-hull/OPi.GPIO

I've currently only tested this in UART mode with the enable pin, and it does work.
I have not yet tried with full GPIO control mode.