### PR TITLE
detect NVIDIA Jetsons which do not have Nvidia in the device tree mod…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         pip install pyserial
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py') --disable=C0103 --disable=W0511 --extension-pkg-whitelist=RPi
+        pylint $(git ls-files '*.py') --disable=C0103 --disable=W0511 --disable=W0012 --extension-pkg-whitelist=RPi
 
   unittest:
     runs-on: ubuntu-latest

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -4,6 +4,7 @@
 #pylint: disable=too-many-public-methods
 #pylint: disable=too-many-branches
 #pylint: disable=too-many-instance-attributes
+#pylint: disable=too-many-positional-arguments
 #pylint: disable=import-outside-toplevel
 #pylint: disable=bare-except
 """TMC_2209 stepper driver module

--- a/src/TMC_2209/_TMC_2209_GPIO_board.py
+++ b/src/TMC_2209/_TMC_2209_GPIO_board.py
@@ -108,7 +108,7 @@ else:
                     "Exiting..."),
                 Loglevel.ERROR)
                 raise
-        elif "nvidia jetson" in model:
+        elif "jetson" in model:
             try:
                 from Jetson import GPIO
                 BOARD = Board.NVIDIA_JETSON


### PR DESCRIPTION
The NVidia Jetson AGX Orin developer kit with Jetpack 5 does not have the name NVidia in /proc/device-tree/model. It should be enough to look for the name "Jetson" to detect NVidia Jetsons reliably.