### PR TITLE
version 0.5.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report or your bug
 title: ''
 labels: ''
 assignees: ''
@@ -20,7 +20,8 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Versions**
-- Raspberry Pi Version
+- Board model
+- Board model Version
 - OS Version
 - Version of this library
 - TMC2209 version and manufacturer

--- a/.github/ISSUE_TEMPLATE/new_board_request.md
+++ b/.github/ISSUE_TEMPLATE/new_board_request.md
@@ -11,7 +11,7 @@ assignees: ''
 
 - the name and a link to you board
 - a library that can be used to control the gpios of your board
-- a info to the serial port of your board
+- an info to the serial port of your board
 
 **Board Identification**
 A method to recognize the new board programmatically. ideally with the output of

--- a/.github/ISSUE_TEMPLATE/uart_problem_report.md
+++ b/.github/ISSUE_TEMPLATE/uart_problem_report.md
@@ -1,6 +1,6 @@
 ---
 name: UART connection problem report
-about: Create a report to help us improve
+about: Create a report of you UART connection problem
 title: ''
 labels: ''
 assignees: ''
@@ -25,7 +25,8 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Versions**
-- Raspberry Pi Version
+- Board model
+- Board model Version
 - OS Version
 - Version of this library
 - TMC2209 version and manufacturer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         pip install pyserial
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py') --disable=C0103 --disable=W0511 --disable=W0012 --extension-pkg-whitelist=RPi
+        pylint $(git ls-files '*.py') --disable=C0103 --disable=W0511 --disable=W0012 --extension-pkg-whitelist=RPi --max-line-length=160
 
   unittest:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.9", "3.13"]
+        python-version: ["3.9", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.9", "3.13"]
+        python-version: ["3.9", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## version 0.5.7
+
+- refactored GPIO access to use inherited classes
+- use mapping table for mapping gpio library to the board
+- fixed print output in test_uart()
+- make fullsteps_per_rev configurable in constructor
+
 ## version 0.5.6
 
 - fixed return status instead of hardcoded True in test_uart

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = TMC_2209_Raspberry_Pi
-version = 0.5.6
+version = 0.5.7
 author = Christian Köhlke
 author_email = christian@koehlke.de
 description = this is a Python libary to drive a stepper motor with a Trinamic TMC2209 stepper driver and a Raspberry Pi

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -141,6 +141,7 @@ class TMC_2209:
         self.tmc_logger = TMC_logger(loglevel, logprefix, log_handlers, log_formatter)
         self.tmc_uart = tmc_uart(self.tmc_logger, serialport, baudrate, driver_address)
 
+        self._fullsteps_per_rev = fullsteps_per_rev
 
         self.tmc_logger.log("Init", Loglevel.INFO)
         TMC_gpio.init(gpio_mode)
@@ -171,8 +172,6 @@ class TMC_2209:
 
         self.set_max_speed_fullstep(100)
         self.set_acceleration_fullstep(100)
-
-        self._fullsteps_per_rev = fullsteps_per_rev
 
 
 

--- a/src/TMC_2209/TMC_2209_StepperDriver.py
+++ b/src/TMC_2209/TMC_2209_StepperDriver.py
@@ -74,7 +74,7 @@ class TMC_2209:
 
     _msres = -1
     _steps_per_rev = 0
-    _fullsteps_per_rev = 200
+    _fullsteps_per_rev = 0
 
     _current_pos = 0                 # current position of stepper in steps
     _target_pos = 0                  # the target position in steps
@@ -113,7 +113,8 @@ class TMC_2209:
                  logprefix=None,
                  log_handlers: list = None,
                  log_formatter : logging.Formatter = None,
-                 skip_uart_init: bool = False
+                 skip_uart_init: bool = False,
+                 fullsteps_per_rev: int = 200
                  ):
         """constructor
 
@@ -170,6 +171,8 @@ class TMC_2209:
 
         self.set_max_speed_fullstep(100)
         self.set_acceleration_fullstep(100)
+
+        self._fullsteps_per_rev = fullsteps_per_rev
 
 
 

--- a/src/TMC_2209/_TMC_2209_GPIO_board.py
+++ b/src/TMC_2209/_TMC_2209_GPIO_board.py
@@ -3,6 +3,9 @@
 #pylint: disable=unknown-option-value
 #pylint: disable=possibly-used-before-assignment
 #pylint: disable=used-before-assignment
+#pylint: disable=unnecessary-pass
+#pylint: disable=abstract-method
+#pylint: disable=no-member
 """
 Many boards have RaspberryPI-compatible PinOut,
 but require to import special GPIO module instead RPI.GPIO
@@ -274,7 +277,7 @@ def handle_module_not_found_error(err, board_name, module_name, install_link):
          f"{install_link}\n"
          "Exiting..."),
         Loglevel.ERROR)
-    raise
+    raise err
 
 def handle_import_error(err, board_name, module_name, install_link):
     """handle import error"""
@@ -285,7 +288,7 @@ def handle_import_error(err, board_name, module_name, install_link):
          f"{install_link}\n"
          "Exiting..."),
         Loglevel.ERROR)
-    raise
+    raise err
 
 def initialize_gpio():
     """initialize GPIO"""

--- a/src/TMC_2209/_TMC_2209_GPIO_board.py
+++ b/src/TMC_2209/_TMC_2209_GPIO_board.py
@@ -15,6 +15,7 @@ Can be extended to support BeagleBone or other boards
 
 from os.path import exists
 from enum import Enum, IntEnum
+from importlib import import_module
 from ._TMC_2209_logger import TMC_logger, Loglevel
 
 # ------------------------------
@@ -36,6 +37,7 @@ class Board(Enum):
     LUCKFOX_PICO = 4
     ORANGE_PI = 5
 
+
 class Gpio(IntEnum):
     """GPIO value"""
     LOW = 0
@@ -52,225 +54,235 @@ class GpioPUD(IntEnum):
     PUD_UP = 22
     PUD_DOWN = 21
 
-
-
-
-
 BOARD = Board.UNKNOWN
 dependencies_logger = TMC_logger(Loglevel.DEBUG, "DEPENDENCIES")
 
-if not exists('/proc/device-tree/model'):
-    from Mock import GPIO
-else:
+
+class BaseGPIOWrapper:
+    """Base class for GPIO implementations"""
+    def init(self, gpio_mode=None):
+        raise NotImplementedError
+
+    def deinit(self):
+        raise NotImplementedError
+
+    def gpio_setup(self, pin, mode, initial=Gpio.LOW, pull_up_down=GpioPUD.PUD_OFF):
+        raise NotImplementedError
+
+    def gpio_cleanup(self, pin):
+        raise NotImplementedError
+
+    def gpio_input(self, pin):
+        raise NotImplementedError
+
+    def gpio_output(self, pin, value):
+        raise NotImplementedError
+
+    def gpio_add_event_detect(self, pin, callback):
+        raise NotImplementedError
+
+    def gpio_remove_event_detect(self, pin):
+        raise NotImplementedError
+
+class BaseRPiGPIOWrapper(BaseGPIOWrapper):
+    """RPI.GPIO implementation"""
+
+    def init(self, gpio_mode=None):
+        self.GPIO.setwarnings(False)
+        if gpio_mode is None:
+            gpio_mode = self.GPIO.BCM
+        self.GPIO.setmode(gpio_mode)
+
+    def deinit(self):
+        self.GPIO.cleanup()
+
+    def gpio_setup(self, pin, mode, initial=Gpio.LOW, pull_up_down=GpioPUD.PUD_OFF):
+        initial = int(initial)
+        pull_up_down = int(pull_up_down)
+        mode = int(mode)
+        if mode == GpioMode.OUT:
+            self.GPIO.setup(pin, mode, initial=initial)
+        else:
+            self.GPIO.setup(pin, mode, pull_up_down=pull_up_down)
+
+    def gpio_cleanup(self, pin):
+        self.GPIO.cleanup(pin)
+
+    def gpio_input(self, pin):
+        return self.GPIO.input(pin)
+
+    def gpio_output(self, pin, value):
+        self.GPIO.output(pin, value)
+
+    def gpio_add_event_detect(self, pin, callback):
+        self.GPIO.add_event_detect(pin, self.GPIO.RISING, callback=callback, bouncetime=300)
+
+    def gpio_remove_event_detect(self, pin):
+       self.GPIO.remove_event_detect(pin)
+
+class MockGPIOWrapper(BaseRPiGPIOWrapper):
+    """Mock GPIO implementation"""
+
+    def __init__(self):
+        self.GPIO = import_module('Mock.GPIO')
+        dependencies_logger.log("using Mock.GPIO for GPIO mocking", Loglevel.INFO)
+
+class RPiGPIOWrapper(BaseRPiGPIOWrapper):
+    """Raspberry Pi GPIO implementation"""
+
+    def __init__(self):
+        self.GPIO = import_module('RPi.GPIO')
+        dependencies_logger.log("using RPi.GPIO for GPIO control", Loglevel.INFO)
+
+class GpiozeroWrapper(BaseRPiGPIOWrapper):
+    """Raspberry Pi 5 GPIO implementation"""
+
+    def __init__(self):
+        self.gpiozero = import_module('gpiozero')
+        dependencies_logger.log("using gpiozero for GPIO control", Loglevel.INFO)
+        self._gpios = [None] * 200
+
+    def init(self, gpio_mode=None):
+        pass
+
+    def deinit(self):
+        pass
+
+    def gpio_setup(self, pin, mode, initial=Gpio.LOW, pull_up_down=GpioPUD.PUD_OFF):
+        if mode == GpioMode.OUT:
+            self._gpios[pin] = self.gpiozero.DigitalOutputDevice(pin)
+        else:
+            self._gpios[pin] = self.gpiozero.DigitalInputDevice(pin)
+
+    def gpio_cleanup(self, pin):
+        self._gpios[pin].close()
+
+    def gpio_input(self, pin):
+        return self._gpios[pin].value
+
+    def gpio_output(self, pin, value):
+        self._gpios[pin].value = value
+
+    def gpio_add_event_detect(self, pin, callback):
+        self._gpios[pin].when_activated = callback
+
+    def gpio_remove_event_detect(self, pin):
+        if self._gpios[pin].when_activated is not None:
+            self._gpios[pin].when_activated = None
+
+class JetsonGPIOWrapper(BaseRPiGPIOWrapper):
+
+    def __init__(self):
+        self.GPIO = import_module('Jetson.GPIO')
+        dependencies_logger.log("using Jetson.GPIO for GPIO control", Loglevel.INFO)
+
+class peripheryWrapper(BaseRPiGPIOWrapper):
+    """Luckfox Pico GPIO implementation"""
+    def __init__(self):
+        self.periphery = import_module('periphery')
+        dependencies_logger.log("using periphery for GPIO control", Loglevel.INFO)
+        self._gpios = [None] * 200
+
+    def init(self, gpio_mode=None):
+        pass
+
+    def deinit(self):
+        pass
+
+    def gpio_setup(self, pin, mode, initial=Gpio.LOW, pull_up_down=GpioPUD.PUD_OFF):
+        mode = 'out' if (mode == GpioMode.OUT) else 'in'
+        self._gpios[pin] = self.periphery.GPIO(pin, mode)
+
+    def gpio_cleanup(self, pin):
+        self._gpios[pin].close()
+
+    def gpio_input(self, pin):
+        return self._gpios[pin].read()
+
+    def gpio_output(self, pin, value):
+        self._gpios[pin].write(bool(value))
+
+class OPiGPIOWrapper(BaseRPiGPIOWrapper):
+    """Orange Pi GPIO implementation"""
+
+    def __init__(self):
+        self.GPIO = import_module('OPi.GPIO')
+        dependencies_logger.log("using OPi.GPIO for GPIO control", Loglevel.INFO)
+
+
+# Determine the board and instantiate the appropriate GPIO class
+def get_board_model_name():
+    if not exists('/proc/device-tree/model'):
+        return "mock"
     with open('/proc/device-tree/model', encoding="utf-8") as f:
-        model = f.readline().lower()
-        if "raspberry pi 5" in model:
-            try:
-                from gpiozero import DigitalOutputDevice, DigitalInputDevice
-                BOARD = Board.RASPBERRY_PI5
-            except ModuleNotFoundError as err:
-                dependencies_logger.log(
-                    (f"ModuleNotFoundError: {err}\n"
-                    "Board is Raspberry PI 5 but module gpiozero isn't installed.\n"
-                    "Follow the installation instructions in the link below to resolve the issue:\n"
-                    "https://gpiozero.readthedocs.io/en/stable/installing.html\n"
-                    "Exiting..."),
-                Loglevel.ERROR)
-                raise
-            except ImportError as err:
-                dependencies_logger.log(
-                    (f"ImportError: {err}\n"
-                    "Board is Raspberry PI 5 but module gpiozero isn't installed.\n"
-                    "Follow the installation instructions in the link below to resolve the issue:\n"
-                    "https://gpiozero.readthedocs.io/en/stable/installing.html\n"
-                    "Exiting..."),
-                Loglevel.ERROR)
-                raise
-        elif "raspberry" in model:
-            try:
-                from RPi import GPIO
-                BOARD = Board.RASPBERRY_PI
-            except ModuleNotFoundError as err:
-                dependencies_logger.log(
-                    (f"ModuleNotFoundError: {err}\n"
-                    "Board is Raspberry PI but module RPi.GPIO isn't installed.\n"
-                    "Follow the installation instructions in the link below to resolve the issue:\n"
-                    "https://sourceforge.net/p/raspberry-gpio-python/wiki/install\n"
-                    "Exiting..."),
-                Loglevel.ERROR)
-                raise
-            except ImportError as err:
-                dependencies_logger.log(
-                    (f"ImportError: {err}\n"
-                    "Board is Raspberry PI but module RPi.GPIO isn't installed.\n"
-                    "Follow the installation instructions in the link below to resolve the issue:\n"
-                    "https://sourceforge.net/p/raspberry-gpio-python/wiki/install\n"
-                    "Exiting..."),
-                Loglevel.ERROR)
-                raise
-        elif "jetson" in model:
-            try:
-                from Jetson import GPIO
-                BOARD = Board.NVIDIA_JETSON
-            except ModuleNotFoundError as err:
-                dependencies_logger.log(
-                    (f"ModuleNotFoundError: {err}\n"
-                    "Board is Nvidia Jetson but module jetson-gpio isn't installed.\n"
-                    "Follow the installation instructions in the link below to resolve the issue:\n"
-                    "https://github.com/NVIDIA/jetson-gpio\n"
-                    "Exiting..."),
-                Loglevel.ERROR)
-                raise
-            except ImportError as err:
-                dependencies_logger.log(
-                    (f"ImportError: {err}\n"
-                    "Board is Nvidia Jetson but module jetson-gpio isn't installed.\n"
-                    "Follow the installation instructions in the link below to resolve the issue:\n"
-                    "https://github.com/NVIDIA/jetson-gpio\n"
-                    "Exiting..."),
-                Loglevel.ERROR)
-                raise
-        elif "luckfox pico" in model:
-            try:
-                from periphery import GPIO
-                BOARD = Board.LUCKFOX_PICO
-            except ModuleNotFoundError as err:
-                dependencies_logger.log(
-                    (f"ModuleNotFoundError: {err}\n"
-                    "Board is Luckfox Pico but module periphery isn't installed.\n"
-                    "Follow the installation instructions in the link below to resolve the issue:\n"
-                    "https://github.com/vsergeev/python-periphery\n"
-                    "Exiting..."),
-                Loglevel.ERROR)
-                raise
-            except ImportError as err:
-                dependencies_logger.log(
-                    (f"ImportError: {err}\n"
-                    "Board is Luckfox Pico but module periphery isn't installed.\n"
-                    "Follow the installation instructions in the link below to resolve the issue:\n"
-                    "https://github.com/vsergeev/python-periphery\n"
-                    "Exiting..."),
-                Loglevel.ERROR)
-                raise
-        elif "orange" in model:
-            try:
-                from OPi import GPIO
-                BOARD = Board.ORANGE_PI
-            except ModuleNotFoundError as err:
-                dependencies_logger.log(
-                    (f"ModuleNotFoundError: {err}\n"
-                    "Board is Orange Pi but module OPi.GPIO isn't installed.\n"
-                    "Follow the installation instructions in the link below to resolve the issue:\n"
-                    "https://github.com/rm-hull/OPi.GPIO\n"
-                    "Exiting..."),
-                Loglevel.ERROR)
-                raise
-        else:
-            # just in case
-            dependencies_logger.log(
-                "The board is not recognized. Trying import default RPi.GPIO module...",
-                Loglevel.INFO)
-            BOARD = Board.UNKNOWN
-            try:
-                from RPi import GPIO
-            except ImportError:
-                from Mock import GPIO
+        return f.readline().lower()
 
+def handle_module_not_found_error(err, board_name, module_name, install_link):
+    dependencies_logger.log(
+        (f"ModuleNotFoundError: {err}\n"
+         f"Board is {board_name} but module {module_name} isn't installed.\n"
+         f"Follow the installation instructions in the link below to resolve the issue:\n"
+         f"{install_link}\n"
+         "Exiting..."),
+        Loglevel.ERROR)
+    raise
 
+def handle_import_error(err, board_name, module_name, install_link):
+    dependencies_logger.log(
+        (f"ImportError: {err}\n"
+         f"Board is {board_name} but module {module_name} isn't installed.\n"
+         f"Follow the installation instructions in the link below to resolve the issue:\n"
+         f"{install_link}\n"
+         "Exiting..."),
+        Loglevel.ERROR)
+    raise
 
-class TMC_gpio:
-    """TMC_gpio class"""
+def initialize_gpio():
+    model = get_board_model_name()
+    dependencies_logger.log(f"Board model: {model}", Loglevel.INFO)
+    if model == "mock":
+        return MockGPIOWrapper(), Board.UNKNOWN
 
-    _gpios = [None] * 200
+    if "raspberry pi 5" in model:
+        try:
+            return GpiozeroWrapper(), Board.RASPBERRY_PI5
+        except ModuleNotFoundError as err:
+            handle_module_not_found_error(err, "Raspberry PI 5", "gpiozero", "https://gpiozero.readthedocs.io/en/stable/installing.html")
+        except ImportError as err:
+            handle_import_error(err, "Raspberry PI 5", "gpiozero", "https://gpiozero.readthedocs.io/en/stable/installing.html")
+    elif "raspberry" in model:
+        try:
+            return RPiGPIOWrapper(), Board.RASPBERRY_PI
+        except ModuleNotFoundError as err:
+            handle_module_not_found_error(err, "Raspberry PI", "RPi.GPIO", "https://sourceforge.net/p/raspberry-gpio-python/wiki/install")
+        except ImportError as err:
+            handle_import_error(err, "Raspberry PI", "RPi.GPIO", "https://sourceforge.net/p/raspberry-gpio-python/wiki/install")
+    elif "jetson" in model:
+        try:
+            return JetsonGPIOWrapper(), Board.NVIDIA_JETSON
+        except ModuleNotFoundError as err:
+            handle_module_not_found_error(err, "Nvidia Jetson", "jetson-gpio", "https://github.com/NVIDIA/jetson-gpio")
+        except ImportError as err:
+            handle_import_error(err, "Nvidia Jetson", "jetson-gpio", "https://github.com/NVIDIA/jetson-gpio")
+    elif "luckfox" in model:
+        try:
+            return peripheryWrapper(), Board.LUCKFOX_PICO
+        except ModuleNotFoundError as err:
+            handle_module_not_found_error(err, "Luckfox Pico", "periphery", "https://github.com/vsergeev/python-periphery")
+        except ImportError as err:
+            handle_import_error(err, "Luckfox Pico", "periphery", "https://github.com/vsergeev/python-periphery")
+    elif "orange" in model:
+        try:
+            return OPiGPIOWrapper(), Board.ORANGE_PI
+        except ModuleNotFoundError as err:
+            handle_module_not_found_error(err, "Orange Pi", "OPi.GPIO", "https://github.com/rm-hull/OPi.GPIO")
+    else:
+        dependencies_logger.log(
+            "The board is not recognized. Trying import default RPi.GPIO module...",
+            Loglevel.INFO)
+        try:
+            return RPiGPIOWrapper(), Board.UNKNOWN
+        except ImportError:
+            return MockGPIOWrapper(), Board.UNKNOWN
 
-    @staticmethod
-    def init(gpio_mode=None):
-        """init gpio library"""
-        if BOARD == Board.RASPBERRY_PI5:
-            pass
-        elif BOARD == Board.LUCKFOX_PICO:
-            pass
-        elif BOARD == Board.ORANGE_PI:
-            pass
-        else:
-            GPIO.setwarnings(False)
-            if gpio_mode is None:
-                gpio_mode = GPIO.BCM
-            GPIO.setmode(gpio_mode)
-
-    @staticmethod
-    def deinit():
-        """deinit gpio library"""
-        if BOARD == Board.RASPBERRY_PI5:
-            pass
-        else:
-            pass
-
-    @staticmethod
-    def gpio_setup(pin, mode, initial = Gpio.LOW, pull_up_down = GpioPUD.PUD_OFF):
-        """setup gpio pin"""
-        #print(f"{BOARD}, {pin}, {mode}")
-        if BOARD == Board.RASPBERRY_PI5:
-            if mode == GpioMode.OUT:
-                TMC_gpio._gpios[pin] = DigitalOutputDevice(pin)
-            else:
-                TMC_gpio._gpios[pin] = DigitalInputDevice(pin)
-        elif BOARD == Board.LUCKFOX_PICO:
-            mode = 'out' if (mode == GpioMode.OUT) else 'in'
-            TMC_gpio._gpios[pin] = GPIO(pin, mode)
-        else:
-            initial = int(initial)
-            pull_up_down = int(pull_up_down)
-            mode = int(mode)
-            if mode == GpioMode.OUT: # TODO: better way to pass different params
-                GPIO.setup(pin, mode, initial=initial)
-            else:
-                GPIO.setup(pin, mode, pull_up_down=pull_up_down)
-
-    @staticmethod
-    def gpio_cleanup(pin):
-        """cleanup gpio pin"""
-        if BOARD == Board.RASPBERRY_PI5:
-            TMC_gpio._gpios[pin].close()
-        elif BOARD == Board.LUCKFOX_PICO:
-            TMC_gpio._gpios[pin].close()
-        else:
-            GPIO.cleanup(pin)
-
-    @staticmethod
-    def gpio_input(pin):
-        """get input value of gpio pin"""
-        del pin
-        return 0 # TODO: implement
-
-    @staticmethod
-    def gpio_output(pin, value):
-        """set output value of gpio pin"""
-        if BOARD == Board.RASPBERRY_PI5:
-            TMC_gpio._gpios[pin].value = value
-        elif BOARD == Board.LUCKFOX_PICO:
-            TMC_gpio._gpios[pin].write(bool(value))
-        else:
-            GPIO.output(pin, value)
-
-    @staticmethod
-    def gpio_add_event_detect(pin, callback):
-        """add event detect"""
-        if BOARD == Board.RASPBERRY_PI5:
-            TMC_gpio._gpios[pin].when_activated = callback
-        elif BOARD == Board.LUCKFOX_PICO:
-            pass # TODO: implement for stallguard
-        else:
-            GPIO.add_event_detect(pin, GPIO.RISING, callback=callback,
-                                bouncetime=300)
-
-    @staticmethod
-    def gpio_remove_event_detect(pin):
-        """remove event dectect"""
-        if BOARD == Board.RASPBERRY_PI5:
-            if TMC_gpio._gpios[pin].when_activated is not None:
-                TMC_gpio._gpios[pin].when_activated = None
-        elif BOARD == Board.LUCKFOX_PICO:
-            pass # TODO: implement for stallguard
-        else:
-            GPIO.remove_event_detect(pin)
+TMC_gpio, BOARD = initialize_gpio()

--- a/src/TMC_2209/_TMC_2209_test.py
+++ b/src/TMC_2209/_TMC_2209_test.py
@@ -104,15 +104,15 @@ def test_uart(self):
     self.tmc_logger.log(str(snd.hex()), Loglevel.DEBUG)
     self.tmc_logger.log(str(rtn.hex()), Loglevel.DEBUG)
 
-    self.tmc_logger.log("just the first 4 bits:", Loglevel.DEBUG)
+    self.tmc_logger.log("just the first 4 bytes:", Loglevel.DEBUG)
     self.tmc_logger.log(str(snd[0:4].hex()), Loglevel.DEBUG)
     self.tmc_logger.log(str(rtn[0:4].hex()), Loglevel.DEBUG)
 
     if len(rtn)==12:
         self.tmc_logger.log("""the Raspberry Pi received the sent
-                            bits and the answer from the TMC""", Loglevel.DEBUG)
+                            bytes and the answer from the TMC""", Loglevel.DEBUG)
     elif len(rtn)==4:
-        self.tmc_logger.log("the Raspberry Pi received only the sent bits",
+        self.tmc_logger.log("the Raspberry Pi received only the sent bytes",
                             Loglevel.ERROR)
         status = False
     elif len(rtn)==0:
@@ -120,16 +120,16 @@ def test_uart(self):
                             Loglevel.ERROR)
         status = False
     else:
-        self.tmc_logger.log(f"the Raspberry Pi received an unexpected amount of bits: {len(rtn)}",
+        self.tmc_logger.log(f"the Raspberry Pi received an unexpected amount of bytes: {len(rtn)}",
                             Loglevel.ERROR)
         status = False
 
     if snd[0:4] == rtn[0:4]:
-        self.tmc_logger.log("""the Raspberry Pi received exactly the bits it has send.
-                    the first 4 bits are the same""", Loglevel.DEBUG)
+        self.tmc_logger.log("""the Raspberry Pi received exactly the bytes it has send.
+                    the first 4 bytes are the same""", Loglevel.DEBUG)
     else:
-        self.tmc_logger.log("""the Raspberry Pi did not received the bits it has send.
-                    the first 4 bits are different""", Loglevel.DEBUG)
+        self.tmc_logger.log("""the Raspberry Pi did not received the bytes it has send.
+                    the first 4 bytes are different""", Loglevel.DEBUG)
         status = False
 
     self.tmc_logger.log("---")


### PR DESCRIPTION
- refactored GPIO access to use inherited classes
- use mapping table for mapping gpio library to the board
- fixed print output in test_uart()
- make fullsteps_per_rev configurable in constructor

Since i have only a Raspberry Pi4, i cant test the GPIO interfaces for the other boards. So there may be mistakes